### PR TITLE
Update README with shortcut correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ or press `alt+option+cmd+k`
 
 | Plateform | Key                  |
 | --------- | -------------------- |
-| MAC       | **alt+option+cmd+k** |
+| MAC       | **ctrl+alt+cmd+k** |
 | Window    | **ctrl+shift+k**     |
 
 ## Contributors ✨


### PR DESCRIPTION
I think `option` and `alt` are the same on Mac keyboards (mine at least). Double checked the [config in package.json](https://github.com/nomi9995/react-native-component-splitter/blob/master/package.json#L52) to verify. 

Thanks!